### PR TITLE
Make it easier to find source from npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,14 @@
   ],
   "author": "James Newell <james@jameslnewell.dev>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jameslnewell/buildkite-pipelines.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jameslnewell/buildkite-pipelines/issues"
+  },
+  "homepage": "https://github.com/jameslnewell/buildkite-pipelines",
   "packageManager": "pnpm@8.6.6",
   "dependencies": {
     "debug": "^4.3.4",


### PR DESCRIPTION
I was failing with Google trying to find JS/TS tools for working with Buildkite pipelines. So, I went to npmjs.com to search for packages with "buildkite" in the name or description and found this wonderful package.

However, there was no easy link to find the source. Googling failed me again (Buildkite searches insist on bringing me to Buildkite's site). I finally found you by looking at your other packages on npm.

Anyway, thought this might help future folks 🤷‍♂️ 