### PR TITLE
Group label support

### DIFF
--- a/.changeset/young-ducks-smile.md
+++ b/.changeset/young-ducks-smile.md
@@ -1,0 +1,5 @@
+---
+"@jameslnewell/buildkite-pipelines": patch
+---
+
+Set group key to null, allowing label key to be used instead

--- a/src/builders/GroupStep.test.ts
+++ b/src/builders/GroupStep.test.ts
@@ -9,7 +9,7 @@ describe(GroupStep.name, () => {
   const object = group.build();
 
   test("has group key", () => {
-    expect(object).toHaveProperty("group", "");
+    expect(object).toHaveProperty("group", null);
   });
 
   test("has label key", () => {

--- a/src/builders/GroupStep.ts
+++ b/src/builders/GroupStep.ts
@@ -57,7 +57,7 @@ export class GroupStep implements StepBuilder, KeyBuilder, LabelBuilder, Depende
 
   build(): GroupStepSchema {
     const step: GroupStepSchema = {
-      group: "",
+      group: null,
       ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       // TODO: cannot have group steps nested within groups so refactor steps helper to take a generic arg


### PR DESCRIPTION
Set `group` key to `null` allowing the `label` value to be used instead, keeping with syntax for `CommandStep`.

https://buildkite.com/docs/pipelines/group-step#group-step-attributes
> Name of the group in the UI. In YAML, if you don't want a label, pass a `~`. Can also be provided in the `label` attribute if `null` is provided to the `group` attribute.