### PR TITLE
Make command step composible

### DIFF
--- a/.changeset/old-bugs-invent.md
+++ b/.changeset/old-bugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@jameslnewell/buildkite-pipelines": patch
+---
+
+Standardise command output to always generate an array

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -2,12 +2,15 @@
 
 exports[`integration matches snapshot 1`] = `
 "steps:
-  - command: npm run lint
+  - commands:
+      - npm run lint
     label: \\":eslint: Lint\\"
-  - command: npm run test
+  - commands:
+      - npm run test
     key: unit-test
     label: \\":jest: Test\\"
-  - command: npm run upload:coverage
+  - commands:
+      - npm run upload:coverage
     label: \\":upload: Upload coverage\\"
     depends_on:
       - unit-test

--- a/src/builders/CommandStep.test.ts
+++ b/src/builders/CommandStep.test.ts
@@ -18,17 +18,14 @@ const dockerPlugin = "docker#v3.11.0";
 
 describe(CommandStep.name, () => {
   describe("command", () => {
-    test("string when string", () => {
+    test("array when single value", () => {
       const step = new CommandStep().command(installCommand).build();
-      expect(step).toHaveProperty("command", installCommand);
+      expect(step).toHaveProperty("commands", [installCommand]);
     });
-    test("array when array length == 1", () => {
-      const step = new CommandStep().command([installCommand]).build();
-      expect(step).toHaveProperty("command", [installCommand]);
-    });
-    test("array when array length > 1", () => {
+    test("array when multiple commands provided", () => {
       const step = new CommandStep()
-        .command([installCommand, buildCommand])
+        .command(installCommand)
+        .command(buildCommand)
         .build();
       expect(step).toHaveProperty("commands", [installCommand, buildCommand]);
     });

--- a/src/builders/CommandStep.ts
+++ b/src/builders/CommandStep.ts
@@ -22,7 +22,7 @@ export class CommandStep
     DependenciesBuilder,
     SkipBuilder
 {
-  #command?: string | string[];
+  #commands?: string[];
   #plugins: Array<PluginSchema | PluginBuilder> = [];
   #keyHelper = new KeyHelper();
   #labelHelper = new LabelHelper();
@@ -38,8 +38,11 @@ export class CommandStep
   #soft_fail?: boolean;
   #timeout_in_minutes?: number;
 
-  command(command: string | string[]): this {
-    this.#command = command;
+  command(command: string): this {
+    if (!this.#commands) {
+      this.#commands = [];
+    }
+    this.#commands.push(command);
     return this;
   }
 
@@ -123,12 +126,8 @@ export class CommandStep
   }
 
   build(): CommandStepSchema {
-    const commandKey =
-      this.#command && Array.isArray(this.#command) && this.#command.length > 1
-        ? "commands"
-        : "command";
     const object: CommandStepSchema = {
-      ...{ [commandKey]: this.#command },
+      ...{ commands: this.#commands },
       ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       ...this.#conditionHelper.build(),


### PR DESCRIPTION
- Updates `command` key to always produce an array
- Allow `CommandStep.command` to be chained to align with other array values
```
new CommandStep()
    .command('some command')
    .command('some other command')
```