### PR TITLE
Fix GroupStep validation errors

### DIFF
--- a/.changeset/nice-icons-fry.md
+++ b/.changeset/nice-icons-fry.md
@@ -1,0 +1,5 @@
+---
+"@jameslnewell/buildkite-pipelines": patch
+---
+
+Fix GroupStep validation errors

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -2,8 +2,7 @@
 
 exports[`integration matches snapshot 1`] = `
 "steps:
-  - group: \\"null\\"
-    label: \\":eslint: Lint group\\"
+  - label: \\":eslint: Lint group\\"
     steps:
       - commands:
           - npm run lint

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -2,9 +2,12 @@
 
 exports[`integration matches snapshot 1`] = `
 "steps:
-  - commands:
-      - npm run lint
-    label: \\":eslint: Lint\\"
+  - group: \\"null\\"
+    label: \\":eslint: Lint group\\"
+    steps:
+      - commands:
+          - npm run lint
+        label: \\":eslint: Lint\\"
   - commands:
       - npm run test
     key: unit-test

--- a/src/__snapshots__/integration.test.ts.snap
+++ b/src/__snapshots__/integration.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`integration matches snapshot 1`] = `
 "steps:
-  - label: \\":eslint: Lint group\\"
+  - group: \\":eslint: Lint group\\"
+    label: \\":eslint: Lint group\\"
     steps:
       - commands:
           - npm run lint

--- a/src/builders/GroupStep.test.ts
+++ b/src/builders/GroupStep.test.ts
@@ -8,10 +8,6 @@ describe(GroupStep.name, () => {
   const group = new GroupStep().label(label).step(command);
   const object = group.build();
 
-  test("has group key", () => {
-    expect(object).toHaveProperty("group", "null");
-  });
-
   test("has label key", () => {
     expect(object).toHaveProperty("label", label);
   });

--- a/src/builders/GroupStep.test.ts
+++ b/src/builders/GroupStep.test.ts
@@ -12,6 +12,10 @@ describe(GroupStep.name, () => {
     expect(object).toHaveProperty("label", label);
   });
 
+  test("has group key", () => {
+    expect(object).toHaveProperty("group", label);
+  });
+
   test("has steps", () => {
     expect(object).toHaveProperty(
       "steps",

--- a/src/builders/GroupStep.test.ts
+++ b/src/builders/GroupStep.test.ts
@@ -9,7 +9,7 @@ describe(GroupStep.name, () => {
   const object = group.build();
 
   test("has group key", () => {
-    expect(object).toHaveProperty("group", null);
+    expect(object).toHaveProperty("group", "null");
   });
 
   test("has label key", () => {

--- a/src/builders/GroupStep.ts
+++ b/src/builders/GroupStep.ts
@@ -57,6 +57,8 @@ export class GroupStep implements StepBuilder, KeyBuilder, LabelBuilder, Depende
 
   build(): GroupStepSchema {
     const step: GroupStepSchema = {
+      // Workaround until the schema is updated to make `group` nullable
+      group: this.#labelHelper.build().label ?? '',
       ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       // TODO: cannot have group steps nested within groups so refactor steps helper to take a generic arg

--- a/src/builders/GroupStep.ts
+++ b/src/builders/GroupStep.ts
@@ -57,7 +57,7 @@ export class GroupStep implements StepBuilder, KeyBuilder, LabelBuilder, Depende
 
   build(): GroupStepSchema {
     const step: GroupStepSchema = {
-      group: null,
+      group: 'null',
       ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       // TODO: cannot have group steps nested within groups so refactor steps helper to take a generic arg

--- a/src/builders/GroupStep.ts
+++ b/src/builders/GroupStep.ts
@@ -57,7 +57,6 @@ export class GroupStep implements StepBuilder, KeyBuilder, LabelBuilder, Depende
 
   build(): GroupStepSchema {
     const step: GroupStepSchema = {
-      group: 'null',
       ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       // TODO: cannot have group steps nested within groups so refactor steps helper to take a generic arg

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,44 +1,36 @@
-import { stringify, validate } from './api'
-import { CommandStep, WaitStep } from './builders'
-import { BlockStep } from './builders/BlockStep'
-import {Pipeline} from './builders/Pipeline'
-import { DockerPlugin } from './builders/contrib'
+import { stringify, validate } from "./api";
+import { CommandStep, GroupStep, WaitStep } from "./builders";
+import { BlockStep } from "./builders/BlockStep";
+import { Pipeline } from "./builders/Pipeline";
+import { DockerPlugin } from "./builders/contrib";
 
-describe('integration', () => {
-  test('matches snapshot', () => {
+describe("integration", () => {
+  test("matches snapshot", () => {
     const pipeline = new Pipeline()
       .step(
-        new CommandStep()
-          .label(':eslint: Lint')
-          .command('npm run lint')
-      )
-      .step(
-        new CommandStep()
-          .label(':jest: Test')
-          .command('npm run test')
-          .key('unit-test')
-      )
-      .step(
-        new CommandStep()
-          .label(':upload: Upload coverage')
-          .command('npm run upload:coverage')
-          .dependOn('unit-test')
-          .plugin(
-            new DockerPlugin()
-              .image('codeclimate/codeclimate')
+        new GroupStep()
+          .label(":eslint: Lint group")
+          .step(
+            new CommandStep().label(":eslint: Lint").command("npm run lint")
           )
       )
       .step(
-        new WaitStep()
+        new CommandStep()
+          .label(":jest: Test")
+          .command("npm run test")
+          .key("unit-test")
       )
       .step(
-        new BlockStep()
-          .label('🚀 Release')
-          .key('release')
+        new CommandStep()
+          .label(":upload: Upload coverage")
+          .command("npm run upload:coverage")
+          .dependOn("unit-test")
+          .plugin(new DockerPlugin().image("codeclimate/codeclimate"))
       )
-    ;
-    const object = pipeline.build()
-    expect(validate(object)).toHaveLength(0)
-    expect(stringify(object)).toMatchSnapshot()
-  })
-})
+      .step(new WaitStep())
+      .step(new BlockStep().label("🚀 Release").key("release"));
+    const object = pipeline.build();
+    expect(validate(object)).toHaveLength(0);
+    expect(stringify(object)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
GroupSteps were causing JsonSchema validation failures with the introduction of #13.

Resolve the issue (removing the `group` key) and the group to the integration test.