### PR TITLE
async build fns

### DIFF
--- a/.changeset/few-carrots-flow.md
+++ b/.changeset/few-carrots-flow.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': major
+---
+
+Make .build(), validate() and stringify() functions async"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -94,7 +94,7 @@ const resolve = (id: string) =>
 
       // validate
       log('validating pipeline');
-      const errors = validate(pipeline);
+      const errors = await validate(pipeline);
       if (errors.length) {
         for (const error of errors) {
           console.error(error);
@@ -104,7 +104,7 @@ const resolve = (id: string) =>
       }
 
       log('stringifying pipeline');
-      console.log(stringify(pipeline));
+      console.log(await stringify(pipeline));
     },
   ).argv;
 })();

--- a/src/lib/builders/CommandStep.test.ts
+++ b/src/lib/builders/CommandStep.test.ts
@@ -18,12 +18,12 @@ const dockerPlugin = 'docker#v3.11.0';
 
 describe(CommandStep.name, () => {
   describe('command', () => {
-    test('array when single value', () => {
-      const step = new CommandStep().command(installCommand).build();
+    test('array when single value', async () => {
+      const step = await new CommandStep().command(installCommand).build();
       expect(step).toHaveProperty('commands', [installCommand]);
     });
-    test('array when multiple commands provided', () => {
-      const step = new CommandStep()
+    test('array when multiple commands provided', async () => {
+      const step = await new CommandStep()
         .command(installCommand)
         .command(buildCommand)
         .build();
@@ -32,72 +32,77 @@ describe(CommandStep.name, () => {
   });
 
   describe('env', () => {
-    test('undefined when undefined', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined when undefined', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('env');
     });
-    test('defined when object', () => {
-      const step = new CommandStep().command(':').env('FOO', 'bar').build();
+    test('defined when object', async () => {
+      const step = await new CommandStep()
+        .command(':')
+        .env('FOO', 'bar')
+        .build();
       expect(step).toHaveProperty('env.FOO', 'bar');
     });
   });
 
   describe('plugins', () => {
-    test('undefined when not defined', () => {
-      const step = new CommandStep().command(':');
+    test('undefined when not defined', async () => {
+      const step = await new CommandStep().command(':');
       expect(step.build()).not.toHaveProperty('plugins');
     });
-    test('defined when object', () => {
-      const step = new CommandStep()
+    test('defined when object', async () => {
+      const object = await new CommandStep()
         .command(':')
-        .plugin({[dockerPlugin]: null});
-      expect(step.build()).toHaveProperty('plugins.0', {
+        .plugin({[dockerPlugin]: null})
+        .build();
+      expect(object).toHaveProperty('plugins.0', {
         [dockerPlugin]: null,
       });
     });
-    test('defined when builder', () => {
-      const step = new CommandStep()
+    test('defined when builder', async () => {
+      const object = await new CommandStep()
         .command(':')
-        .plugin(new Plugin(dockerPlugin));
-      expect(step.build()).toHaveProperty('plugins.0', {
+        .plugin(new Plugin(dockerPlugin))
+        .build();
+      expect(object).toHaveProperty('plugins.0', {
         [dockerPlugin]: null,
       });
     });
   });
 
   describe('parallelism', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('parallelism');
     });
-    test('defined when 3', () => {
-      const step = new CommandStep().command(':').parallelism(3).build();
+    test('defined when 3', async () => {
+      const step = await new CommandStep().command(':').parallelism(3).build();
       expect(step).toHaveProperty('parallelism', 3);
     });
   });
 
   describe('skip', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('skip');
     });
-    test('defined when true', () => {
-      const step = new CommandStep().command(':').skip(true).build();
+    test('defined when true', async () => {
+      const step = await new CommandStep().command(':').skip(true).build();
       expect(step).toHaveProperty('skip', true);
     });
-    test('defined when false', () => {
-      const step = new CommandStep().command(':').skip(false).build();
+    test('defined when false', async () => {
+      const step = await new CommandStep().command(':').skip(false).build();
       expect(step).toHaveProperty('skip', false);
     });
   });
 
   describe('concurrency', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('concurrency');
     });
-    test('defined when 1', () => {
-      const step = new CommandStep()
+    test('defined when 1', async () => {
+      const step = await new CommandStep()
         .command(':')
         .concurrency('test', 1)
         .build();
@@ -106,12 +111,12 @@ describe(CommandStep.name, () => {
   });
 
   describe('concurrency_group', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('concurrency_group');
     });
-    test('defined when 1', () => {
-      const step = new CommandStep()
+    test('defined when 1', async () => {
+      const step = await new CommandStep()
         .command(':')
         .concurrency('test', 1)
         .build();
@@ -120,37 +125,40 @@ describe(CommandStep.name, () => {
   });
 
   describe('soft_fail', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('soft_fail');
     });
 
-    test('defined when true', () => {
-      const step = new CommandStep().command(':').softFail().build();
+    test('defined when true', async () => {
+      const step = await new CommandStep().command(':').softFail().build();
       expect(step).toHaveProperty('soft_fail', true);
     });
   });
 
   describe('timeout_in_minutes', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('timeout_in_minutes');
     });
 
-    test('defined when 2', () => {
-      const step = new CommandStep().command(':').timeout(2).build();
+    test('defined when 2', async () => {
+      const step = await new CommandStep().command(':').timeout(2).build();
       expect(step).toHaveProperty('timeout_in_minutes', 2);
     });
   });
 
   describe('agents', () => {
-    test('undefined by default', () => {
-      const step = new CommandStep().command(':').build();
+    test('undefined by default', async () => {
+      const step = await new CommandStep().command(':').build();
       expect(step).not.toHaveProperty('agents');
     });
 
-    test('defined when queue specified', () => {
-      const step = new CommandStep().command(':').agent('queue', 'arm').build();
+    test('defined when queue specified', async () => {
+      const step = await new CommandStep()
+        .command(':')
+        .agent('queue', 'arm')
+        .build();
       expect(step).toHaveProperty('agents', {queue: 'arm'});
     });
   });

--- a/src/lib/builders/CommandStep.ts
+++ b/src/lib/builders/CommandStep.ts
@@ -130,7 +130,7 @@ export class CommandStep
     return this;
   }
 
-  build(): CommandStepSchema {
+  async build(): Promise<CommandStepSchema> {
     const object: CommandStepSchema = {
       ...{commands: this.#commands},
       ...this.#keyHelper.build(),
@@ -153,8 +153,10 @@ export class CommandStep
     };
 
     if (this.#plugins.length > 0) {
-      object.plugins = this.#plugins.map((plugin) =>
-        isPluginBuilder(plugin) ? plugin.build() : plugin,
+      object.plugins = await Promise.all(
+        this.#plugins.map(async (plugin) =>
+          isPluginBuilder(plugin) ? await plugin.build() : plugin,
+        ),
       );
     }
 

--- a/src/lib/builders/GroupStep.test.ts
+++ b/src/lib/builders/GroupStep.test.ts
@@ -3,23 +3,26 @@ import {GroupStep} from './GroupStep';
 
 describe(GroupStep.name, () => {
   const label = 'Testing Steps';
-
   const command = new CommandStep().command('yarn run test');
-  const group = new GroupStep().label(label).step(command);
-  const object = group.build();
 
-  test('has label key', () => {
+  test('has label key', async () => {
+    const group = new GroupStep().label(label).step(command);
+    const object = await group.build();
     expect(object).toHaveProperty('label', label);
   });
 
-  test('has group key', () => {
+  test('has group key', async () => {
+    const group = new GroupStep().label(label).step(command);
+    const object = await group.build();
     expect(object).toHaveProperty('group', label);
   });
 
-  test('has steps', () => {
+  test('has steps', async () => {
+    const group = new GroupStep().label(label).step(command);
+    const object = await group.build();
     expect(object).toHaveProperty(
       'steps',
-      expect.arrayContaining([command.build()]),
+      expect.arrayContaining([await command.build()]),
     );
   });
 });

--- a/src/lib/builders/GroupStep.ts
+++ b/src/lib/builders/GroupStep.ts
@@ -64,14 +64,14 @@ export class GroupStep
     return this;
   }
 
-  build(): GroupStepSchema {
+  async build(): Promise<GroupStepSchema> {
     const step: GroupStepSchema = {
       // Workaround until the schema is updated to make `group` nullable
       group: this.#labelHelper.build().label ?? '',
       ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       // TODO: cannot have group steps nested within groups so refactor steps helper to take a generic arg
-      ...(this.#stepsHelper.build() as any),
+      ...((await this.#stepsHelper.build()) as any),
       ...this.skipHelper.build(),
       ...this.dependenciesHelper.build(),
     };

--- a/src/lib/builders/Pipeline.test.ts
+++ b/src/lib/builders/Pipeline.test.ts
@@ -3,13 +3,13 @@ import {CommandStep} from './CommandStep';
 
 describe('Pipeline', () => {
   describe('agents', () => {
-    test('does not have agents when no agents are setup', () => {
-      const pipeline = new Pipeline().build();
+    test('does not have agents when no agents are setup', async () => {
+      const pipeline = await new Pipeline().build();
       expect(pipeline).not.toHaveProperty('agents');
     });
 
-    test('has agents when agents are setup', () => {
-      const pipeline = new Pipeline().agent('queue', 'macos').build();
+    test('has agents when agents are setup', async () => {
+      const pipeline = await new Pipeline().agent('queue', 'macos').build();
       expect(pipeline).toHaveProperty(
         'agents',
         expect.objectContaining({queue: 'macos'}),
@@ -18,14 +18,14 @@ describe('Pipeline', () => {
   });
 
   describe('notifications', () => {
-    test('does not have notifications when no notifications are setup', () => {
-      const pipeline = new Pipeline().build();
+    test('does not have notifications when no notifications are setup', async () => {
+      const pipeline = await new Pipeline().build();
       expect(pipeline).not.toHaveProperty('notify');
     });
 
-    test('has notifications when notifications are setup', () => {
+    test('has notifications when notifications are setup', async () => {
       const notification = {email: 'james@example.com'};
-      const pipeline = new Pipeline().notify(notification).build();
+      const pipeline = await new Pipeline().notify(notification).build();
       expect(pipeline).toHaveProperty(
         'notify',
         expect.arrayContaining([notification]),
@@ -33,11 +33,11 @@ describe('Pipeline', () => {
     });
   });
 
-  test('has steps', () => {
+  test('has steps', async () => {
     const step1 = new CommandStep().command('echo "hello"');
     const step2 = new CommandStep().command('echo "world"');
 
-    const pipeline = new Pipeline().step(step1).step(step2).build();
+    const pipeline = await new Pipeline().step(step1).step(step2).build();
 
     expect(pipeline).toHaveProperty(
       'steps',

--- a/src/lib/builders/Pipeline.ts
+++ b/src/lib/builders/Pipeline.ts
@@ -33,11 +33,11 @@ export class Pipeline
     return this;
   }
 
-  build(): PipelineSchema {
+  async build(): Promise<PipelineSchema> {
     const pipeline: PipelineSchema = {
       ...this.#agentsHelper.build(),
       ...this.#notifyHelper.build(),
-      ...this.#stepsHelper.build(),
+      ...(await this.#stepsHelper.build()),
     };
     return pipeline;
   }

--- a/src/lib/builders/PipelineBuilder.ts
+++ b/src/lib/builders/PipelineBuilder.ts
@@ -1,5 +1,5 @@
 import {PipelineSchema} from '../schema';
 
 export interface PipelineBuilder {
-  build(): PipelineSchema;
+  build(): PipelineSchema | Promise<PipelineSchema>;
 }

--- a/src/lib/builders/PluginBuilder.ts
+++ b/src/lib/builders/PluginBuilder.ts
@@ -1,5 +1,5 @@
 import {PluginSchema} from '../schema';
 
 export interface PluginBuilder {
-  build(): PluginSchema;
+  build(): PluginSchema | Promise<PluginSchema>;
 }

--- a/src/lib/builders/StepBuilder.ts
+++ b/src/lib/builders/StepBuilder.ts
@@ -1,5 +1,5 @@
 import {StepSchema} from '../schema';
 
 export interface StepBuilder {
-  build(): StepSchema;
+  build(): StepSchema | Promise<StepSchema>;
 }

--- a/src/lib/builders/helpers/steps.ts
+++ b/src/lib/builders/helpers/steps.ts
@@ -13,11 +13,13 @@ export class StepsHelper {
     this.#steps.push(step);
   }
 
-  build() {
+  async build() {
     return this.#steps.length > 0
       ? {
-          steps: this.#steps.map((step) =>
-            isStepBuilder(step) ? step.build() : step,
+          steps: await Promise.all(
+            this.#steps.map(async (step) =>
+              isStepBuilder(step) ? await step.build() : step,
+            ),
           ),
         }
       : {};

--- a/src/lib/integration.test.ts
+++ b/src/lib/integration.test.ts
@@ -5,7 +5,7 @@ import {Pipeline} from './builders/Pipeline';
 import {DockerPlugin} from './builders/contrib';
 
 describe('integration', () => {
-  test('matches snapshot', () => {
+  test('matches snapshot', async () => {
     const pipeline = new Pipeline()
       .step(
         new GroupStep()
@@ -30,8 +30,8 @@ describe('integration', () => {
       )
       .step(new WaitStep())
       .step(new BlockStep().label('🚀 Release').key('release'));
-    const object = pipeline.build();
-    expect(validate(object)).toHaveLength(0);
-    expect(stringify(object)).toMatchSnapshot();
+    const object = await pipeline.build();
+    expect(await validate(object)).toHaveLength(0);
+    expect(await stringify(object)).toMatchSnapshot();
   });
 });

--- a/src/lib/utilities/stringify.test.ts
+++ b/src/lib/utilities/stringify.test.ts
@@ -1,8 +1,8 @@
 import {stringify} from './stringify';
 
 describe('stringify()', () => {
-  test('outputs a yaml string', () => {
-    const result = stringify({
+  test('outputs a yaml string', async () => {
+    const result = await stringify({
       steps: [
         {
           label: 'lint',

--- a/src/lib/utilities/stringify.ts
+++ b/src/lib/utilities/stringify.ts
@@ -4,9 +4,11 @@ import {PipelineSchema} from '../schema';
 import {PipelineBuilder} from '../builders';
 import {isPipelineBuilder} from '../builders/isPipelineBuilder';
 
-export function stringify(pipeline: PipelineSchema | PipelineBuilder): string {
+export async function stringify(
+  pipeline: PipelineSchema | PipelineBuilder,
+): Promise<string> {
   return prettier.format(
-    yaml.dump(isPipelineBuilder(pipeline) ? pipeline.build() : pipeline, {
+    yaml.dump(isPipelineBuilder(pipeline) ? await pipeline.build() : pipeline, {
       styles: {
         sortKeys: true,
         noRefs: true,

--- a/src/lib/utilities/validate.test.ts
+++ b/src/lib/utilities/validate.test.ts
@@ -1,22 +1,22 @@
 import {validate} from './validate';
 
 describe(validate.name, () => {
-  test('returns 0 errors when valid', () => {
-    const errors = validate({
+  test('returns 0 errors when valid', async () => {
+    const errors = await validate({
       steps: [],
     });
     expect(errors);
   });
 
-  test('returns >0 errors when invalid', () => {
-    const errors = validate({
+  test('returns >0 errors when invalid', async () => {
+    const errors = await validate({
       steps: [{foo: 'bar'} as any],
     });
     expect(errors.length).toBeGreaterThan(0);
   });
 
-  test('returns structured errors when invalid', () => {
-    const errors = validate({
+  test('returns structured errors when invalid', async () => {
+    const errors = await validate({
       steps: [{command: 'echo "Hello World!"', timeout_in_minutes: 0}],
     });
     expect(errors).toContainEqual(

--- a/src/lib/utilities/validate.ts
+++ b/src/lib/utilities/validate.ts
@@ -16,11 +16,11 @@ const ajv = new Ajv({
 
 const schemaValidator = ajv.compile(schemaJSON);
 
-export function validate(
+export async function validate(
   pipeline: PipelineSchema | PipelineBuilder,
-): Array<ErrorObject> {
+): Promise<Array<ErrorObject>> {
   const valid = schemaValidator(
-    isPipelineBuilder(pipeline) ? pipeline.build() : pipeline,
+    isPipelineBuilder(pipeline) ? await pipeline.build() : pipeline,
   );
   return !valid && schemaValidator.errors ? schemaValidator.errors : [];
 }


### PR DESCRIPTION
🤔 Not sure if we should merge this PR...

---

The `buildkite-pipelines` CLI supports async pipeline factories e.g.
```js
import { Pipeline } from '@jameslnewell/buildkite-pipelines'

export const pipeline = async () => {

  // 👇 async operation
  const metadata = await obtainSomeMetadataAsynchronously()

  // 👇 pipeline construction
  return new Pipeline().notify({slack: metadata.slack})

}
```

Factory functions can easily be extracted and made reusable e.g.
```js
import { Pipeline } from '@jameslnewell/buildkite-pipelines'
import { createPipelineWithNotifications } from '@my-org/buildkite-pipelines'

export const pipeline = createPipelineWithNotifications()
```

However, when using a builder pattern, currently the async operation needs to be performed externally to the builder which limits the all-encompassing nature of the abstraction and results in repetition in the places the abstraction is reused e.g.
```js
class ServicePipeline implements PipelineBuilder {
  constructor(metadata) {
    this.metadata = metadata
  }

  async build() {

    // 👇 pipeline construction
    return new Pipeline().notify({slack: this.metadata.slack})

  }
}

export const pipeline = async () => {

  // 👇 async operation
  const metadata = await obtainSomeMetadataAsynchronously()
  
  return new ServicePipeline(metadata)

}

```


This PR makes the `.build()` fns in the builder pattern `async` so builder abstractions can do async things to construct the pipeline e.g.

```js
class ServicePipeline implements PipelineBuilder {
  async build() {

    // 👇 async operation
    const metadata = await obtainSomeMetadataAsynchronously()

    // 👇 pipeline construction
    return new Pipeline().notify({slack: metadata.slack})

  }
}

export const pipeline = new ServicePipeline()

```

This change only benefits users of the library who are using the builder pattern for their own abstractions, but the change impacts _all_ users of the library as almost every function (`validate`, `stringify`, `.build()`) now needs to be async regardless of whether they rely on the async nature or not.
