### PR TITLE
when a single glob is provided, use a string to workaround ignore-missing issue 

### DIFF
--- a/.changeset/khaki-gorillas-jog.md
+++ b/.changeset/khaki-gorillas-jog.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': minor
+---
+
+work around artifacts ignore-missing issue by outputing a single download/upload instead of an array when there is only a single value

--- a/src/lib/builders/contrib/ArtifactsPlugin.test.ts
+++ b/src/lib/builders/contrib/ArtifactsPlugin.test.ts
@@ -9,19 +9,30 @@ describe(ArtifactsPlugin.name, () => {
     );
   });
 
-  describe('.download()', () => {
-    test('is not defined when not specified', async () => {
+  describe('.addDownload()', () => {
+    test('is not defined when download not specified', async () => {
       const plugin = new ArtifactsPlugin();
       expect((await plugin.build())[ArtifactsPlugin.PLUGIN]).not.toHaveProperty(
         'download',
       );
     });
-    test('is an array when specified', async () => {
+    test('is a string when a single download is specified', async () => {
       const glob = '*.log';
-      const plugin = new ArtifactsPlugin().download(glob);
+      const plugin = new ArtifactsPlugin().addDownload(glob);
       expect((await plugin.build())[ArtifactsPlugin.PLUGIN]).toHaveProperty(
         'download',
-        [glob],
+        glob,
+      );
+    });
+    test('is an array when more than one download is specified', async () => {
+      const glob1 = '*.log';
+      const glob2 = '*.txt';
+      const plugin = new ArtifactsPlugin()
+        .addDownload(glob1)
+        .addDownload(glob2);
+      expect((await plugin.build())[ArtifactsPlugin.PLUGIN]).toHaveProperty(
+        'download',
+        [glob1, glob2],
       );
     });
   });
@@ -32,12 +43,21 @@ describe(ArtifactsPlugin.name, () => {
         'upload',
       );
     });
-    test('is an array when specified', async () => {
+    test('is a string when a single upload is specified', async () => {
       const glob = '*.log';
-      const plugin = new ArtifactsPlugin().upload(glob);
+      const plugin = new ArtifactsPlugin().addUpload(glob);
       expect((await plugin.build())[ArtifactsPlugin.PLUGIN]).toHaveProperty(
         'upload',
-        [glob],
+        glob,
+      );
+    });
+    test('is an array when more than one upload is specified', async () => {
+      const glob1 = '*.log';
+      const glob2 = '*.txt';
+      const plugin = new ArtifactsPlugin().addUpload(glob1).addUpload(glob2);
+      expect((await plugin.build())[ArtifactsPlugin.PLUGIN]).toHaveProperty(
+        'upload',
+        [glob1, glob2],
       );
     });
   });

--- a/src/lib/builders/contrib/ArtifactsPlugin.ts
+++ b/src/lib/builders/contrib/ArtifactsPlugin.ts
@@ -5,7 +5,7 @@ import {PluginBuilder} from '../PluginBuilder';
  * @see https://github.com/buildkite-plugins/artifacts-buildkite-plugin
  */
 export class ArtifactsPlugin implements PluginBuilder {
-  static PLUGIN = 'artifacts#v1.9.2';
+  static PLUGIN = 'artifacts#v1.9.3';
 
   #downloads: string[] = [];
   #uploads: string[] = [];
@@ -26,25 +26,41 @@ export class ArtifactsPlugin implements PluginBuilder {
   }
 
   /**
-   * @deprecated Use .setDownload() instead
+   * @deprecated Use .addDownload() instead
    */
   download(file: string): this {
-    return this.setDownload(file);
+    return this.addDownload(file);
   }
 
+  /**
+   * @deprecated Use .addDownload() instead
+   */
   setDownload(glob: string): this {
+    this.addDownload(glob);
+    return this;
+  }
+
+  addDownload(glob: string): this {
     this.#downloads.push(glob);
     return this;
   }
 
   /**
-   * @deprecated Use .setUpload() instead
+   * @deprecated Use .addUpload() instead
    */
   upload(glob: string): this {
-    return this.setUpload(glob);
+    return this.addUpload(glob);
   }
 
+  /**
+   * @deprecated Use .addUpload() instead
+   */
   setUpload(glob: string): this {
+    this.addUpload(glob);
+    return this;
+  }
+
+  addUpload(glob: string): this {
     this.#uploads.push(glob);
     return this;
   }
@@ -87,11 +103,13 @@ export class ArtifactsPlugin implements PluginBuilder {
 
   build(): PluginSchema | Promise<PluginSchema> {
     if (this.#downloads.length) {
-      this.#options['download'] = this.#downloads;
+      this.#options['download'] =
+        this.#downloads.length === 1 ? this.#downloads[0] : this.#downloads;
     }
 
     if (this.#uploads.length) {
-      this.#options['upload'] = this.#uploads;
+      this.#options['upload'] =
+        this.#uploads.length === 1 ? this.#uploads[0] : this.#uploads;
     }
 
     if (this.#skipOnStatus.length) {


### PR DESCRIPTION
when only a single glob is provided, use a string to [workaround ignore-missing issue ](https://github.com/buildkite-plugins/artifacts-buildkite-plugin/issues/89#issuecomment-1958501061)

