### PR TITLE
add key to trigger step

### DIFF
--- a/.changeset/rotten-bikes-eat.md
+++ b/.changeset/rotten-bikes-eat.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': minor
+---
+
+Added key to Trigger step

--- a/src/lib/builders/TriggerStep.ts
+++ b/src/lib/builders/TriggerStep.ts
@@ -3,11 +3,13 @@ import {StepBuilder} from './StepBuilder';
 import {BranchFilterBuilder, BranchFilterHelper} from './helpers/branches';
 import {ConditionBuilder, ConditionHelper} from './helpers/condition';
 import {DependenciesBuilder, DependenciesHelper} from './helpers/dependencies';
+import {KeyBuilder, KeyHelper} from './helpers/key';
 import {LabelBuilder, LabelHelper} from './helpers/label';
 import {SkipBuilder, SkipHelper} from './helpers/skip';
 
 export class TriggerStep
   implements
+    KeyBuilder,
     StepBuilder,
     LabelBuilder,
     BranchFilterBuilder,
@@ -19,6 +21,7 @@ export class TriggerStep
   #async?: boolean;
   #softFail?: boolean;
   #build?: TriggerStepSchema['build'];
+  #keyHelper = new KeyHelper();
   #labelHelper = new LabelHelper();
   #branchesHelper = new BranchFilterHelper();
   #conditionHelper = new ConditionHelper();
@@ -42,6 +45,11 @@ export class TriggerStep
 
   setBuild(build: TriggerStepSchema['build']): this {
     this.#build = build;
+    return this;
+  }
+
+  setKey(key: string): this {
+    this.#keyHelper.setKey(key);
     return this;
   }
 
@@ -121,6 +129,7 @@ export class TriggerStep
   build(): TriggerStepSchema | Promise<TriggerStepSchema> {
     const object: TriggerStepSchema = {
       trigger: this.#pipeline,
+      ...this.#keyHelper.build(),
       ...this.#labelHelper.build(),
       ...this.#branchesHelper.build(),
       ...this.#conditionHelper.build(),

--- a/src/lib/builders/TriggerStep.ts
+++ b/src/lib/builders/TriggerStep.ts
@@ -48,6 +48,13 @@ export class TriggerStep
     return this;
   }
 
+  /**
+   * @deprecated Use .setKey() instead
+   */
+  key(key: string): this {
+    return this.setKey(key);
+  }
+
   setKey(key: string): this {
     this.#keyHelper.setKey(key);
     return this;


### PR DESCRIPTION

> key	A unique string to identify the trigger step.
Keys can not have the same pattern as a UUID (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
Example: "trigger-deploy"
Alias: identifier

https://buildkite.com/docs/pipelines/configure/step-types/trigger-step