### PR TITLE
Fix BlockStep and WaitStep silently dropping setCondition()

### DIFF
--- a/.changeset/blockstep-waitstep-condition.md
+++ b/.changeset/blockstep-waitstep-condition.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': patch
+---
+
+Fix `BlockStep` and `WaitStep` silently dropping `setCondition()` when building the pipeline schema. The condition value is now emitted as the `if` field, matching `CommandStep` and `TriggerStep`.

--- a/src/lib/builders/BlockStep.test.ts
+++ b/src/lib/builders/BlockStep.test.ts
@@ -47,4 +47,10 @@ describe(BlockStep.name, () => {
     const step = new BlockStep().setLabel(label).addField(field);
     expect((await step.build()).fields).toContain(field);
   });
+
+  test('has condition', async () => {
+    const condition = 'build.branch == "main"';
+    const step = new BlockStep().setLabel(label).setCondition(condition);
+    expect((await step.build()).if).toEqual(condition);
+  });
 });

--- a/src/lib/builders/BlockStep.ts
+++ b/src/lib/builders/BlockStep.ts
@@ -169,6 +169,7 @@ export class BlockStep
       ...this.#branchesHelper.build(),
       ...this.#dependenciesHelper.build(),
       ...this.#promptHelper.build(),
+      ...this.#conditionHelper.build(),
     };
 
     if (this.#state) {

--- a/src/lib/builders/WaitStep.test.ts
+++ b/src/lib/builders/WaitStep.test.ts
@@ -27,4 +27,9 @@ describe(WaitStep.name, () => {
     const wait = new WaitStep().setKey(key);
     expect((await wait.build()).key).toEqual(key);
   });
+  test('has condition', async () => {
+    const condition = 'build.branch == "main"';
+    const wait = new WaitStep().setCondition(condition);
+    expect((await wait.build()).if).toEqual(condition);
+  });
 });

--- a/src/lib/builders/WaitStep.ts
+++ b/src/lib/builders/WaitStep.ts
@@ -90,6 +90,7 @@ export class WaitStep
       wait: null,
       ...this.#dependenciesHelper.build(),
       ...this.#keyHelper.build(),
+      ...this.#conditionHelper.build(),
     };
 
     if (this.#continueOnFailure !== undefined) {


### PR DESCRIPTION
## Why

`BlockStep` and `WaitStep` both expose `setCondition()` (and the deprecated `condition()`) and route the value through a `ConditionHelper`, but their `build()` methods never spread `#conditionHelper.build()` into the emitted schema. The condition is therefore silently dropped — callers get no error, no warning, and the generated pipeline runs the step unconditionally. `CommandStep` and `TriggerStep` already wire the helper in correctly.

## What changed

- `BlockStep.build()` and `WaitStep.build()` now spread `...this.#conditionHelper.build()` so the value is emitted as the `if` field, matching the other step types.
- Added `has condition` regression tests in `BlockStep.test.ts` and `WaitStep.test.ts` that build a step with `setCondition()` and assert the resulting `if` field.
- Added a patch changeset.

No public API changes; this is a pure bug fix.