### PR TITLE
Bump CI to Node 24 and fix npm publish step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v2
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v2
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v2
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v2
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 24
       - uses: pnpm/action-setup@v2
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -159,9 +159,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
       - uses: pnpm/action-setup@v2
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
## Why

The `publish-package` job has been failing on every push to `main` since at least early March — most recently after merging #69. The root cause is that Node 22.22.2 in the GitHub-hosted toolcache ships with a broken bundled npm: `@npmcli/arborist/lib/arborist/rebuild.js` can't resolve `promise-retry`, so the workflow's `npm install -g npm@latest` step crashes with `MODULE_NOT_FOUND` before it ever reaches `npm publish`.

We were only doing the manual npm upgrade because Node 22's bundled npm was too old for OIDC trusted publishing. Node 24 ships with npm 11.x, which already supports OIDC, so the upgrade step is dead weight.

## What changed

- Bumped every job's `node-version` from `16` (and `22` on `publish-package`) to `24`.
- Removed the `npm install -g npm@latest` step from `publish-package` — Node 24's bundled npm is sufficient.

No source changes; this is CI-only. No `.nvmrc` or `engines` field exists in the repo, so nothing else needed updating.