### PR TITLE
Enable Dependabot with auto-merge for minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      - id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Intent

Have Dependabot keep dependencies up to date and merge minor and patch updates without manual intervention — but only if CI passes.

## Why

Routine npm / GitHub Actions / Docker base-image bumps eat attention. For non-breaking (minor/patch) updates on a small library, manually reviewing each PR adds friction without much risk, especially when CI catches regressions. This frees attention for the major-version PRs that actually need a human.

## What changed

- `.github/dependabot.yml` — weekly npm, github-actions, and docker (for `docker/Dockerfile`) update PRs, capped at 10 open at once.
- `.github/workflows/dependabot-auto-merge.yml` — on any Dependabot PR, classify the bump via `dependabot/fetch-metadata`; for patch or minor, enable GitHub's native auto-merge (squash). Major bumps stay open for manual review.

The existing CI workflow is untouched; it already runs on every push so it triggers on Dependabot branches automatically. A repo ruleset on `main` (added separately) makes the relevant CI jobs *required* status checks so `--auto` actually waits for them before merging.