### PR TITLE
Use a RELEASE_TOKEN PAT for the publish push

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -161,7 +161,7 @@ jobs:
           # Use a PAT so the bump commit + tag can be pushed back to `main` —
           # the default GITHUB_TOKEN is blocked by the `main: require CI`
           # ruleset (github-actions[bot] is not in the bypass list).
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 24

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -157,6 +157,11 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Use a PAT so the bump commit + tag can be pushed back to `main` —
+          # the default GITHUB_TOKEN is blocked by the `main: require CI`
+          # ruleset (github-actions[bot] is not in the bypass list).
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 24


### PR DESCRIPTION
## Intent

Make the publish job's push to `main` actually work under the `main: require CI` ruleset by signing the push with a personal access token that bypasses required status checks.

## Why

The new ruleset on `main` requires CI status checks to pass before any update — including direct pushes. The publish job's bump commit + tag is a *new* commit (no checks have run on it yet), so the push is rejected with `GH013: Repository rule violations`. Verified once empirically:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - N of N required status checks are expected.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

`github-actions[bot]` (the identity used by GITHUB_TOKEN) isn't recognised as the Write or Admin role for the ruleset's bypass list, so role-based bypass doesn't help. A fine-grained PAT owned by an admin user *does* bypass cleanly. (Verified: pushing the post-publish version bump from my admin account succeeded with `remote: Bypassed rule violations for refs/heads/main`.)

## What changed

`actions/checkout` in the publish job (and `GH_TOKEN` for `auto shipit`) now consume `${{ secrets.RELEASE_TOKEN }}` instead of the default `GITHUB_TOKEN`. Everything else is untouched.

## Required setup before merging

1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - **Resource owner**: jameslnewell
   - **Repository access**: Only select repositories → tick `buildkite-pipelines`, `github-changes`, `git-diff` (one token works for all three)
   - **Permissions**: `Contents: Read and write`, `Metadata: Read-only` (default)
2. Add the token as a repository secret named `RELEASE_TOKEN` on each of the three repos.

(Or use a classic PAT with `repo` scope — slightly broader but also works.)