### PR TITLE
Skip publish-package when no changesets are pending

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -186,15 +186,33 @@ jobs:
           name: package-dist
           path: dist
       - run: pnpm run changeset version
-      - id: version
+      - id: bump
+        # Skip the rest of the publish job when `changeset version` had no
+        # pending changesets to apply — otherwise `npm publish` is run with
+        # the already-published version and fails with
+        # `You cannot publish over the previously published versions`.
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No pending changesets — skipping publish."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.bump.outputs.skip != 'true'
+        id: version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-      - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - run: git config --global user.name "github-actions[bot]"
-      - run: git commit -am "Bumped package versions 📦" || echo "Versions not updated. Nothing to commit."
-        shell: bash {0} # opt-out of exit on error
-      - run: git push
-      - run: git push --follow-tags
-      - run: npm publish
+      - if: steps.bump.outputs.skip != 'true'
+        run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - if: steps.bump.outputs.skip != 'true'
+        run: git config --global user.name "github-actions[bot]"
+      - if: steps.bump.outputs.skip != 'true'
+        run: git commit -am "Bumped package versions 📦"
+      - if: steps.bump.outputs.skip != 'true'
+        run: git push
+      - if: steps.bump.outputs.skip != 'true'
+        run: git push --follow-tags
+      - if: steps.bump.outputs.skip != 'true'
+        run: npm publish
 
   docker-push:
     name: '⬆️🐳 Publishing to DockerHub'


### PR DESCRIPTION
## Intent

Stop the `publish-package` job from failing on every routine push to `main` that doesn't actually contain a changeset.

## Why

The job's `npm publish` step is unconditional. When `pnpm run changeset version` finds no pending `.changeset/*.md` files, nothing is bumped — `git commit -am "Bumped..."` exits non-zero (caught by the existing `|| echo` swallow) and `git push` is a no-op, but the workflow then runs `npm publish` against the already-published `package.json` version. Result on the most recent main push:

```
npm error You cannot publish over the previously published versions: 3.22.2.
npm error A complete log of this run can be found in: ...
##[error]Process completed with exit code 1.
```

So every PR merge that doesn't include a `.changeset/*.md` produces a red CI run on main. This is the pre-existing bug we flagged after the ruleset + PAT work — it's independent of both.

## What changed

After `pnpm run changeset version`, a new `bump` step inspects `git status --porcelain`. If the working tree is clean (no changeset was applied), it sets `skip=true` and the subsequent commit / push / `npm publish` steps are all gated by `if: steps.bump.outputs.skip != 'true'`.

When there *are* pending changesets, behaviour is unchanged: the bump is committed, pushed (now via `RELEASE_GITHUB_TOKEN` from the previous PR), and published.

Side cleanup: dropped the `|| echo "Versions not updated. Nothing to commit."` swallow and the `shell: bash {0}` opt-out — they were only there to paper over the same "no changeset" case that we now handle properly upstream.

## Verification

Once merged, the next push to `main` that has no pending changeset should produce a green run where the bump/commit/push/publish steps all show as skipped (grey) rather than red. A push that does include a changeset should still go all the way through — same path as before, just with the `if` evaluating true.