### PR TITLE
Require a changeset on every PR via CI

### DIFF
--- a/.changeset/require-changeset-on-every-pr.md
+++ b/.changeset/require-changeset-on-every-pr.md
@@ -1,0 +1,5 @@
+---
+"@jameslnewell/buildkite-pipelines": patch
+---
+
+CI now requires every PR to include a changeset (Dependabot exempted).

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,34 @@
+name: 🦋 Changeset
+
+on: pull_request
+
+jobs:
+  changeset:
+    name: '🦋 Require changeset'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a changeset file
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Dependabot PRs do not include changesets — release notes for their
+          # bumps roll into the next changeset-bearing PR.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Dependabot PR — changeset not required."
+            exit 0
+          fi
+          added=$(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- '.changeset/*.md' \
+            | grep -v '/README\.md$' || true)
+          if [ -z "$added" ]; then
+            echo "::error::This PR must include a changeset. Run \`pnpm changeset\` and commit the generated .changeset/*.md file."
+            exit 1
+          fi
+          echo "Changesets added in this PR:"
+          echo "$added"


### PR DESCRIPTION
## Intent

Make every human PR include a changeset, so the publish job on `main` always has something to release. This replaces the now-closed #88 ("skip publish when no changeset") with the stricter "every PR must declare a release intent" approach.

## Why

`publish-package` calls `pnpm run changeset version` followed by `npm publish`. When a PR merges to `main` without a `.changeset/*.md` file, `changeset version` is a no-op, `package.json` stays on the previously-released version, and `npm publish` then errors with `You cannot publish over the previously published versions: <v>`. Forcing every PR to declare a bump fixes this at the source — every main push that triggers publish now has a real release to do.

## What changed

New workflow `.github/workflows/changeset.yml`:
- Runs on `pull_request` only (so the existing `on: push` CI flow is untouched).
- Single job `🦋 Require changeset` — uses `git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- '.changeset/*.md'` to confirm the PR adds at least one changeset file.
- **Dependabot PRs are exempted** (the step early-exits with success when `pull_request.user.login == 'dependabot[bot]'`). Dependency bumps don't need their own changeset; whatever release notes are appropriate get rolled into the next human PR's changeset. The early-exit is inside a step (not the job) so the check still resolves to `success` rather than `skipped`, satisfying the required-status-check rule on `main`.

## Follow-up (handled separately, not in this PR)

After merging, the ruleset `main: require CI` will be updated to add `🦋 Require changeset` to its required status checks list — otherwise auto-merge would bypass the gate.

## Verification

- Open a PR without a changeset → the `🦋 Require changeset` check fails with: `This PR must include a changeset. Run \`pnpm changeset\` ...`
- Add a `.changeset/*.md` file, push → check goes green.
- A Dependabot PR (any update type) → check goes green automatically, no changeset needed.