### PR TITLE
Skip CI on the publish job's bump commit (and format-fix first)

### DIFF
--- a/.changeset/skip-ci-on-bump-commit.md
+++ b/.changeset/skip-ci-on-bump-commit.md
@@ -1,0 +1,5 @@
+---
+"@jameslnewell/buildkite-pipelines": patch
+---
+
+Stop the publish job's PAT push from cascading into a second `🤖 CI/CD` run that fails at `npm publish` (no pending changeset to consume).

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -186,11 +186,20 @@ jobs:
           name: package-dist
           path: dist
       - run: pnpm run changeset version
+      # Format the files `changeset version` writes (CHANGELOG.md, package.json)
+      # so the bump commit always passes prettier — important because the
+      # commit lands on main with [skip ci], so the formatting check doesn't
+      # run on it directly; without this, format drift here would surface as
+      # a red `check:formatting` on the next PR.
+      - run: pnpm run fix:formatting
       - id: version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
       - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - run: git config --global user.name "github-actions[bot]"
-      - run: git commit -am "Bumped package versions 📦" || echo "Versions not updated. Nothing to commit."
+      # [skip ci] stops the PAT-driven push from cascading into a second
+      # `🤖 CI/CD` run (no pending changeset → npm publish errors with
+      # "cannot publish over the previously published versions").
+      - run: git commit -am "Bumped package versions 📦 [skip ci]" || echo "Versions not updated. Nothing to commit."
         shell: bash {0} # opt-out of exit on error
       - run: git push
       - run: git push --follow-tags


### PR DESCRIPTION
## Intent

Stop the publish job's bump commit from triggering a second, doomed CI/CD run, while keeping main's formatting honest.

## Why

Now that the publish job pushes the version-bump commit with `RELEASE_GITHUB_TOKEN` (a PAT, not the default `GITHUB_TOKEN`), GitHub's recursion-prevention no longer applies — that push triggers another `🤖 CI/CD` run. The secondary run has no pending changeset to consume, so `publish-package` runs `npm publish` against the already-published version and dies with:

```
npm error You cannot publish over the previously published versions: 3.22.3.
##[error]Process completed with exit code 1.
```

Observed once on run [25904617480](https://github.com/jameslnewell/buildkite-pipelines/actions/runs/25904617480) right after #89 merged. The release itself succeeded; only the cascade is red.

`auto`-based repos (`github-changes`, `git-diff`) don't have this problem because `auto`'s default bump-commit message is `Bump version to: X.Y.Z [skip ci]`, and GitHub Actions honours the `[skip ci]` token. This PR brings buildkite-pipelines in line.

## What changed

In `publish-package`:

1. **`pnpm run fix:formatting` runs after `pnpm run changeset version`** — prettier-corrects whatever `CHANGELOG.md` / `package.json` writes the bump produced. Because the bump commit will now land on `main` with `[skip ci]`, `🤖 CI/CD` doesn't run on it, so `check:formatting` doesn't either. Without this step, any format drift from `changeset version` would silently land on main and surface later as a red `check:formatting` on someone's unrelated PR.

2. **Commit message changes** from `Bumped package versions 📦` to `Bumped package versions 📦 [skip ci]` — suppresses the secondary CI run for this specific push only. No effect on subsequent commits / PRs.

## Scope notes

- `[skip ci]` is per-commit, scoped only to the workflow run triggered by *that* push. Future commits, builds, and PR checks are unaffected.
- The `|| echo "Versions not updated..."` swallow is retained as-is since this PR doesn't reopen that area.