### PR TITLE
Redirect imported pipeline stdout to stderr

### DIFF
--- a/.changeset/redirect-pipeline-stdout.md
+++ b/.changeset/redirect-pipeline-stdout.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': patch
+---
+
+CLI now redirects any stdout written from the imported pipeline file (and any function it executes — factories, builders) to stderr so it doesn't get interleaved with the generated YAML on stdout.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -182,9 +182,11 @@ const resolve = (id: string, basedir: string) =>
       log('stringifying pipeline');
       const yaml = await stringify(pipeline);
 
-      // restore stdout so the generated YAML is written to stdout
+      // write the generated YAML to the original stdout
+      originalStdoutWrite(`${yaml}\n`);
+
+      // restore stdout
       process.stdout.write = originalStdoutWrite;
-      console.log(yaml);
     },
   ).argv;
 })();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,6 +46,14 @@ const resolve = (id: string, basedir: string) =>
     async (argv) => {
       const {file, require, cwd} = argv;
 
+      // redirect any stdout writes from the imported pipeline (and any
+      // functions it executes) to stderr so they don't get interleaved
+      // with the generated YAML on stdout
+      const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = process.stderr.write.bind(
+        process.stderr,
+      ) as typeof process.stdout.write;
+
       // change the current working directory
       const basedir = process.cwd();
       if (cwd) process.chdir(cwd);
@@ -172,7 +180,11 @@ const resolve = (id: string, basedir: string) =>
       }
 
       log('stringifying pipeline');
-      console.log(await stringify(pipeline));
+      const yaml = await stringify(pipeline);
+
+      // restore stdout so the generated YAML is written to stdout
+      process.stdout.write = originalStdoutWrite;
+      console.log(yaml);
     },
   ).argv;
 })();


### PR DESCRIPTION
## Summary

Anything the imported pipeline file (and any function it executes — factories, builders) writes to stdout currently gets interleaved with the YAML emitted by the CLI on stdout, which corrupts the output that `buildkite-agent pipeline upload` consumes.

This PR forces any such stdout writes to go to stderr instead, so the YAML is the only thing on stdout. stdout is restored just before the final YAML is printed.

## What changed

- `src/cli/index.ts` — at the top of the command handler, replace `process.stdout.write` with a function that forwards to `process.stderr.write`. Restore the original `process.stdout.write` immediately before `console.log(yaml)` so the generated pipeline still lands on stdout.

Error messages already go through `console.error` (stderr), so they're unaffected.

## Test plan

- [ ] Run the CLI against a pipeline file that calls `console.log(...)` inside its factory/builder — confirm the log lands on stderr and only YAML lands on stdout.
- [ ] Run against a normal pipeline file — confirm YAML output is unchanged.
- [ ] `pnpm run check:typing` + `pnpm run check:formatting` pass.