### PR TITLE
Fix published package shipping no compiled JavaScript

### DIFF
--- a/.changeset/fix-swc-strip-leading-paths.md
+++ b/.changeset/fix-swc-strip-leading-paths.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': patch
+---
+
+Fix the published package shipping only TypeScript declarations and no compiled JavaScript. `@swc/cli` emits to `dist/src/...`, but `files`/`main`/`bin` reference `dist/cli`, `dist/lib` and `dist/__experimental__`, so only the `.d.ts` files written by `tsc` were ever packaged. Build with `--strip-leading-paths` so swc emits to `dist/cli`, `dist/lib` and `dist/__experimental__`, matching the published paths.

--- a/packages/buildkite-pipelines/package.json
+++ b/packages/buildkite-pipelines/package.json
@@ -78,7 +78,7 @@
     "build": "pnpm run build:types && pnpm run build:transpile && pnpm run build:pages",
     "build:pages": "typedoc",
     "build:types": "tsc --declaration --emitDeclarationOnly",
-    "build:transpile": "swc src --out-dir dist --source-maps --copy-files",
+    "build:transpile": "swc src --out-dir dist --source-maps --copy-files --strip-leading-paths",
     "test": "jest --maxWorkers=1",
     "changeset": "changeset",
     "version": "changeset version",


### PR DESCRIPTION
## Intent

Make the published `@jameslnewell/buildkite-pipelines` actually contain runtime JavaScript.

## Why

The published tarball (incl. the live `3.22.5` on npm) contains **only `.d.ts` declarations and zero `.js`** — so `require()` and the CLI `bin` resolve to nothing once installed. `@swc/cli` (0.7+) emits to `dist/src/...`, but `files`/`main`/`bin` reference `dist/cli`, `dist/lib` and `dist/__experimental__`, so only the declarations `tsc` writes to those paths were ever packed. This is a pre-existing bug on `main`, surfaced while converting to a monorepo.

## What changed

- Add `--strip-leading-paths` to the package's `build:transpile` so swc emits straight to `dist/cli`, `dist/lib` and `dist/__experimental__`, matching the published paths.

## Verification

- `npm pack --dry-run` now ships the compiled JS (174 files vs. the broken 58), including `dist/cli/index.js`, `dist/lib/index.js`, `dist/__experimental__/index.js`.
- `require('./dist/lib')` returns the builders; `node dist/cli/index.js --help` runs.

## Notes

Stacked on #94 (monorepo conversion). Carries a `patch` changeset.