### PR TITLE
Fix package check script calling a non-existent script

### DIFF
--- a/.changeset/fix-check-script.md
+++ b/.changeset/fix-check-script.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the package `check` script referencing a non-existent `check:types` script; it now runs `check:typing`. No release required (the script is not part of the published package).

--- a/packages/buildkite-pipelines/package.json
+++ b/packages/buildkite-pipelines/package.json
@@ -69,7 +69,7 @@
   "prettier": "@jameslnewell/prettier-config",
   "scripts": {
     "fix:formatting": "prettier --write .",
-    "check": "pnpm run check:formatting && pnpm run check:types",
+    "check": "pnpm run check:formatting && pnpm run check:typing",
     "check:formatting": "prettier --check .",
     "check:typing": "tsc --noEmit",
     "prepare": "husky && pnpm run codegen",


### PR DESCRIPTION
## Intent

Make `pnpm run check` work for the package.

## Why

The package `check` script chains `check:formatting && check:types`, but the type-check script is named `check:typing`, so `pnpm run check` always fails with "Command check:types not found". CI runs the individual scripts (`check:formatting`, `check:typing`) so it went unnoticed. Pre-existing on `main`.

## What changed

- Point `check` at `check:typing`.

## Verification

`pnpm --filter @jameslnewell/buildkite-pipelines run check` now runs formatting + typing cleanly.

## Notes

Stacked on #94 (monorepo conversion). Carries an empty changeset — dev-only script, not part of the published package.