### PR TITLE
Fix docker-push job version guard and stale references

### DIFF
--- a/.changeset/fix-docker-push-version-guard.md
+++ b/.changeset/fix-docker-push-version-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix the `docker-push` CI job: reference the published version via `needs.publish-package.outputs.version` (not the non-existent `steps.publish-package`), gate the build on a working `docker manifest inspect` exit-code check written to `$GITHUB_OUTPUT` (replacing the deprecated `::set-output` and the broken `steps.version.outputs.pushed` guard). CI-only change; no release required.

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -232,10 +232,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - id: pushed
-        run: echo "::set-output name=pushed::$(docker manifest inspect jameslnewell/buildkite-pipelines:${{ steps.publish-package.outputs.version }} > /dev/null)"
+      # Skip the build when the image for this version is already on DockerHub
+      # (`docker manifest inspect` exits 0 when the tag exists). The version is
+      # the buildkite-pipelines package version published by `publish-package`,
+      # since the image bundles that CLI.
+      - id: image
+        env:
+          VERSION: ${{ needs.publish-package.outputs.version }}
+        run: |
+          if docker manifest inspect "jameslnewell/buildkite-pipelines:$VERSION" > /dev/null 2>&1; then
+            echo "Image jameslnewell/buildkite-pipelines:$VERSION already exists — skipping build."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: docker/build-push-action@v2
-        if: ${{ steps.version.outputs.pushed }} == 1
+        if: steps.image.outputs.exists == 'false'
         with:
           push: true
           context: .


### PR DESCRIPTION
## Intent

Make the `docker-push` CI job's "already published?" guard actually work and stop relying on broken expression references.

## Why

Pre-existing bugs on `main`:
- The `pushed` step referenced `steps.publish-package.outputs.version` — but `publish-package` is a *needed job*, not a step in this job, so the value was empty and `docker manifest inspect` ran against an empty tag.
- It used the deprecated `::set-output` (now a no-op) and gated the build on `steps.version.outputs.pushed`, which doesn't exist in this job — so the idempotency skip never worked and the image was rebuilt every run.

## What changed

- Replace the `pushed` step with an `image` step that checks `docker manifest inspect "…:$VERSION"`'s **exit code** against `needs.publish-package.outputs.version`, writing `exists=true|false` to `$GITHUB_OUTPUT`.
- Gate `build-push-action` on `steps.image.outputs.exists == 'false'`.
- Clarify in a comment that the version is the buildkite-pipelines package version (the image bundles that CLI), which is why it's package-specific.

## Notes

Targets `main` (the monorepo conversion #94 has merged). CI-only change; carries an empty changeset.