### PR TITLE
Make named exports ESM-importable without dropping CommonJS

### DIFF
--- a/.changeset/cjs-analyzable-named-exports.md
+++ b/.changeset/cjs-analyzable-named-exports.md
@@ -1,0 +1,21 @@
+---
+"@jameslnewell/buildkite-pipelines": minor
+---
+
+Make named exports resolvable from pure-ESM consumers (without dropping CommonJS)
+
+Pure-ESM consumers couldn't `import { ECRPlugin, CommandStep, … }` from this
+package: it was transpiled by swc, whose CJS output re-exports barrels via the
+runtime `_export_star` helper, which Node's `cjs-module-lexer` cannot statically
+analyze — so no named exports were visible and ESM consumers failed with
+`SyntaxError: Named export '…' not found`.
+
+Switch the transpile step from swc to `tsc` with `module: "node16"`. tsc emits
+`__exportStar(require(...), exports)` for barrels and `exports.X = X` for leaf
+modules — both patterns `cjs-module-lexer` recognises and recurses through — so
+named imports now resolve from pure-ESM consumers. `node16` also preserves the
+CLI's dynamic `import()`, so user pipeline files authored as ESM still load.
+
+The package remains CommonJS (no `"type": "module"`), so existing
+`require('@jameslnewell/buildkite-pipelines')` consumers are unaffected — hence
+a minor, non-breaking release.

--- a/packages/buildkite-pipelines/package.json
+++ b/packages/buildkite-pipelines/package.json
@@ -78,7 +78,7 @@
     "build": "pnpm run build:types && pnpm run build:transpile && pnpm run build:pages",
     "build:pages": "typedoc",
     "build:types": "tsc --declaration --emitDeclarationOnly",
-    "build:transpile": "swc src --out-dir dist --source-maps --copy-files --strip-leading-paths",
+    "build:transpile": "tsc",
     "test": "jest --maxWorkers=1",
     "changeset": "changeset",
     "version": "changeset version",

--- a/packages/buildkite-pipelines/tsconfig.json
+++ b/packages/buildkite-pipelines/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "skipLibCheck": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "es2018",
     "outDir": "./dist"
     // "exactOptionalPropertyTypes": true


### PR DESCRIPTION
Linear: FF-792

> **Alternative to #108.** Same goal — let pure-ESM consumers named-import the package — but the **minimal, non-breaking** way: it stays CommonJS, so it's a `minor` bump rather than #108's breaking `major`. Opened as a draft for comparison; pick one.

## Why

`@mr-yum/subdomain-pipeline` (pure ESM) does named imports from this package:

```js
import { CommandStep, ECRPlugin, Pipeline /* … */ } from '@jameslnewell/buildkite-pipelines'
```

These failed with `SyntaxError: Named export 'ECRPlugin' not found …`. The root cause is **not** that we're CommonJS — it's that **swc's** CJS output re-exports barrels via the runtime `_export_star` helper, which Node's `cjs-module-lexer` can't statically analyze. So the lexer sees zero named exports and ESM consumers can't import any of them. (Verified: the leaf modules already emit an analyzable `Object.defineProperty(exports, "X", …)`; only the `_export_star` barrels hide the names.)

## What changed

Transpile with **`tsc` (`module: "node16"`)** instead of swc — two lines:

- `build:transpile`: `swc …` → `tsc`
- `tsconfig`: `module: "commonjs"` → `"node16"` (+ `moduleResolution: "node16"`)

tsc emits `__exportStar(require(...), exports)` for barrels and `exports.X = X` for leaves — both patterns `cjs-module-lexer` recognises and recurses through — so named imports resolve from ESM. `module: node16` (rather than `commonjs`) **preserves the CLI's dynamic `import()`** (plain `commonjs` downlevels it to `require()`, which can't load ESM user pipeline files); and because CJS-format files don't require explicit import extensions under `node16`, **no source changes are needed**.

The package stays CommonJS (no `"type": "module"`), so existing `require('@jameslnewell/buildkite-pipelines')` consumers keep working unchanged → **non-breaking, `minor` bump**.

### vs #108 (the ESM `major`)

| | #108 — ESM | This PR — CJS+tsc |
|---|---|---|
| Version bump | major (breaking) | minor (non-breaking) |
| `require()` consumers | broken | still work |
| ESM named import | ✅ | ✅ |
| Source churn | `.js` ext on every import + `type:module` | none (2 lines of config) |
| Build tool | swc (fast) | tsc (slower) |
| Bonus | — | tsc doesn't copy `.snap` into `dist`, so `build && test` no longer trips obsolete-snapshot failures |

Trade-off: drops swc's faster transpile, and ESM consumers get a CJS module via Node's interop (named imports work; no true ESM tree-shaking).

## Why not "just keep swc"?

swc has no flag to make `export *` analyzable — it always emits `_export_star`, and multi-name re-exports compile to its equally-opaque `_export(exports, {…})` helper. Both were verified to fail ESM named-import end-to-end. The transpiler is the fix.

## Verification

```
$ node --input-type=module -e "import { ECRPlugin, CommandStep, Pipeline } from '@jameslnewell/buildkite-pipelines'; console.log(typeof ECRPlugin, typeof CommandStep, typeof Pipeline)"
function function function
```

Against a `npm pack`'d tarball: pure-ESM consumer named-imports (incl. `/__experimental__` subpath) ✅ and CJS `require()` ✅. CLI runs against both `.mjs` (ESM) and `.js` (CJS) pipeline fixtures ✅. `check:typing`, `check:formatting`, and all 138 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)