### PR TITLE
Accept a GroupStep in findSteps/findFirstStep

### DIFF
--- a/.changeset/find-steps-accept-group.md
+++ b/.changeset/find-steps-accept-group.md
@@ -1,0 +1,5 @@
+---
+'@jameslnewell/buildkite-pipelines': minor
+---
+
+`findSteps` and `findFirstStep` now accept a `GroupStep` as their first argument, in addition to a `Pipeline` or an iterable of steps. A passed group is unwrapped to its child steps (the same way a `Pipeline` already is), so callers can write `findSteps(group, predicate)` instead of `findSteps(group.getSteps(), predicate)`.

--- a/packages/buildkite-pipelines/src/__experimental__/findSteps.test.ts
+++ b/packages/buildkite-pipelines/src/__experimental__/findSteps.test.ts
@@ -86,6 +86,19 @@ describe(findSteps, () => {
 
     expect(steps).toEqual([]);
   });
+
+  test('finds the child steps when given a group directly', () => {
+    const group = new GroupStep()
+      .setLabel('Deploying')
+      .addSteps([deployAppAStep, deployAppBStep]);
+
+    const steps = findSteps(
+      group,
+      (step): step is CommandStep => step instanceof CommandStep,
+    );
+
+    expect(steps).toEqual([deployAppAStep, deployAppBStep]);
+  });
 });
 
 describe(findFirstStep, () => {
@@ -144,5 +157,18 @@ describe(findFirstStep, () => {
     );
 
     expect(step).toBeUndefined();
+  });
+
+  test('finds the first child step when given a group directly', () => {
+    const group = new GroupStep()
+      .setLabel('Deploying')
+      .addSteps([deployAppAStep, deployAppBStep]);
+
+    const step = findFirstStep(
+      group,
+      (step): step is CommandStep => step instanceof CommandStep,
+    );
+
+    expect(step).toEqual(deployAppAStep);
   });
 });

--- a/packages/buildkite-pipelines/src/__experimental__/findSteps.ts
+++ b/packages/buildkite-pipelines/src/__experimental__/findSteps.ts
@@ -32,28 +32,39 @@ export interface FindStepsOptions {
 // filter<S extends T>(predicate: (value: T, index: number, array: T[]) => value is S, thisArg?: any): S[];
 
 /**
- * Finds all the steps that match the predicate within a pipeline
+ * Finds all the steps that match the predicate within a pipeline, group, or
+ * iterable of steps
  */
 export function findSteps<S extends StepSchema | StepBuilder>(
-  pipelineOrSteps: Pipeline | Iterable<StepSchema | StepBuilder>,
+  pipelineGroupOrSteps:
+    | Pipeline
+    | GroupStep
+    | Iterable<StepSchema | StepBuilder>,
   predicate: FindStepsNarrowPredicate<S>,
   options?: FindStepsOptions,
 ): ReadonlyArray<S>;
 export function findSteps(
-  pipelineOrSteps: Pipeline | Iterable<StepSchema | StepBuilder>,
+  pipelineGroupOrSteps:
+    | Pipeline
+    | GroupStep
+    | Iterable<StepSchema | StepBuilder>,
   predicate: FindStepsPredicate,
   options?: FindStepsOptions,
 ): ReadonlyArray<StepSchema | StepBuilder>;
 export function findSteps(
-  pipelineOrSteps: Pipeline | Iterable<StepSchema | StepBuilder>,
+  pipelineGroupOrSteps:
+    | Pipeline
+    | GroupStep
+    | Iterable<StepSchema | StepBuilder>,
   predicate: FindStepsPredicate,
   {recursive = true}: FindStepsOptions = {},
 ): ReadonlyArray<StepSchema | StepBuilder> {
-  // if we have a pipeline, get the steps from the pipeline, otherwise get the steps from the iterable
+  // if we have a pipeline or a group, get its child steps; otherwise get the steps from the iterable
   const stepsArray = Array.from(
-    pipelineOrSteps instanceof Pipeline
-      ? Array.from(pipelineOrSteps.getSteps())
-      : pipelineOrSteps,
+    pipelineGroupOrSteps instanceof Pipeline ||
+      pipelineGroupOrSteps instanceof GroupStep
+      ? Array.from(pipelineGroupOrSteps.getSteps())
+      : pipelineGroupOrSteps,
   );
 
   // if recursive=true, add the child steps of any GroupSteps to the array
@@ -87,23 +98,33 @@ function isGroupSchema(
 }
 
 /**
- * Finds the first step that matches the predicate within a pipeline
+ * Finds the first step that matches the predicate within a pipeline, group, or
+ * iterable of steps
  */
 export function findFirstStep<S extends StepSchema | StepBuilder>(
-  pipelineOrSteps: Pipeline | Iterable<StepSchema | StepBuilder>,
+  pipelineGroupOrSteps:
+    | Pipeline
+    | GroupStep
+    | Iterable<StepSchema | StepBuilder>,
   predicate: FindStepsNarrowPredicate<S>,
   options?: FindStepsOptions,
 ): S | undefined;
 export function findFirstStep(
-  pipelineOrSteps: Pipeline | Iterable<StepSchema | StepBuilder>,
+  pipelineGroupOrSteps:
+    | Pipeline
+    | GroupStep
+    | Iterable<StepSchema | StepBuilder>,
   predicate: FindStepsPredicate,
   options?: FindStepsOptions,
 ): StepSchema | StepBuilder | undefined;
 export function findFirstStep(
-  pipelineOrSteps: Pipeline | Iterable<StepSchema | StepBuilder>,
+  pipelineGroupOrSteps:
+    | Pipeline
+    | GroupStep
+    | Iterable<StepSchema | StepBuilder>,
   predicate: FindStepsPredicate,
   options: FindStepsOptions = {},
 ): StepSchema | StepBuilder | undefined {
-  const steps = findSteps(pipelineOrSteps, predicate, options);
+  const steps = findSteps(pipelineGroupOrSteps, predicate, options);
   return steps[0];
 }


### PR DESCRIPTION
## Why

`findSteps`/`findFirstStep` already accept a `Pipeline` and unwrap it into its steps, but a `GroupStep` had to be unwrapped by the caller — e.g. `findSteps(group.getSteps(), predicate)`. That `.getSteps()` boilerplate shows up wherever a consumer wants to search within a single group (it came up building helm-diff checks in `mr-yum/pipeline-packages`).

## What changed

- The first argument of `findSteps` and `findFirstStep` now accepts `Pipeline | GroupStep | Iterable<StepSchema | StepBuilder>`.
- A passed `GroupStep` is unwrapped to its child steps via `.getSteps()`, mirroring the existing `Pipeline` handling. Recursion into nested groups and the `options`/narrowing-predicate behaviour are unchanged.
- Callers can now write `findSteps(group, predicate)` directly.

## Testing

- Added unit tests passing a `GroupStep` directly to both `findSteps` and `findFirstStep`.
- `tsc --noEmit` clean; full suite green (140 tests); prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)